### PR TITLE
fix mail sending bug

### DIFF
--- a/trunk/python/src/mapreduce/lib/pipeline/pipeline.py
+++ b/trunk/python/src/mapreduce/lib/pipeline/pipeline.py
@@ -412,7 +412,7 @@ class Pipeline(object):
 
   # Internal only.
   _class_path = None  # Set for each class
-  _send_mail = mail.send_mail_to_admins  # For testing
+  _send_mail = staticmethod(mail.send_mail_to_admins)  # For testing
 
   def __init__(self, *args, **kwargs):
     """Initializer.


### PR DESCRIPTION
 Attaching the `send_mail_to_admins` function as a class attr of `Pipeline` caused it to become bound, messing up its expected kwargs
